### PR TITLE
Timeout-able get()'s

### DIFF
--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -363,3 +363,42 @@ unittest
 
     client.close();
 }
+
+/**
+ * Client testing
+ *
+ * See above except we test a timeout-based
+ * request future here.
+ *
+ * This test DOES NOT time out (it tests
+ * with a high-enough threshold)
+ */
+unittest
+{
+    CoapClient client = new CoapClient("coap.me", 5683);
+
+    
+    CoapRequestFuture future = client.newRequestBuilder()
+                              .payload(cast(ubyte[])"Hello this is Tristan!")
+                              .token([69])
+                              .post();
+
+    try
+    {
+        writeln("Future start");
+        CoapPacket response  = future.get(dur!("msecs")(400));
+
+        // Ensure that we have the correct state
+        assert(future.getState() == RequestState.COMPLETED);
+
+        // We SHOULD get here
+        assert(true);
+    }
+    catch(RequestTimeoutException e)
+    {
+        // We should NOT time out
+        assert(false);
+    }
+
+    client.close();
+}

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -331,6 +331,8 @@ version(unittest)
  *
  * See above except we test a timeout-based
  * request future here.
+ *
+ * This test DOES time out
  */
 unittest
 {
@@ -359,7 +361,5 @@ unittest
         assert(true);
     }
 
-    writeln("Closing client...");
     client.close();
-    writeln("Client closed");
 }

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -302,21 +302,21 @@ version(unittest)
  */
 unittest
 {
-    // CoapClient client = new CoapClient("coap.me", 5683);
+    CoapClient client = new CoapClient("coap.me", 5683);
 
     
-    // CoapRequestFuture future = client.newRequestBuilder()
-    //                           .payload(cast(ubyte[])"Hello this is Tristan!")
-    //                           .token([69])
-    //                           .post();
+    CoapRequestFuture future = client.newRequestBuilder()
+                              .payload(cast(ubyte[])"Hello this is Tristan!")
+                              .token([69])
+                              .post();
 
 
-    // writeln("Future start");
-    // CoapPacket response  = future.get();
-    // writeln("Future done");
-    // writeln("Got response: ", response);
+    writeln("Future start");
+    CoapPacket response  = future.get();
+    writeln("Future done");
+    writeln("Got response: ", response);
 
-    // client.close();
+    client.close();
 }
 
 version(unittest)

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -112,16 +112,12 @@ public class CoapClient
         this.messaging.close();
         
         // Cancel all active request futures
-        writeln("Awaking any sleeping futures.... (for shutdown)");
         this.requestsLock.lock();
         foreach(CoapRequest curReq; outgoingRequests)
         {
-            writeln("Awaking any sleeping futures.... (for shutdown): ", curReq);
             curReq.future.cancel();
-            writeln("Awaking any sleeping futures.... (for shutdown): ", curReq, " [done]");
         }
         this.requestsLock.unlock();
-        writeln("Awaking any sleeping futures.... (for shutdown) [done]");
     }
 
     /** 
@@ -327,6 +323,7 @@ version(unittest)
 {
     import core.time : dur;
     import doap.client.exceptions : RequestTimeoutException;
+    import doap.client.request : CoapRequestFuture, RequestState;
 }
 
 /**
@@ -344,7 +341,7 @@ unittest
                               .payload(cast(ubyte[])"Hello this is Tristan!")
                               .token([69])
                               .post();
-                              
+
     try
     {
         writeln("Future start");
@@ -355,6 +352,9 @@ unittest
     }
     catch(RequestTimeoutException e)
     {
+        // Ensure that we have the correct state
+        assert(future.getState() == RequestState.TIMEDOUT);
+
         // We SHOULD time out
         assert(true);
     }

--- a/source/doap/client/exceptions.d
+++ b/source/doap/client/exceptions.d
@@ -1,0 +1,44 @@
+module doap.client.exceptions;
+
+import doap.exceptions : CoapException;
+import core.time : Duration;
+
+public class CoapClientException : CoapException
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}
+
+import doap.client.request : CoapRequestFuture;
+import std.conv : to;
+
+package final class RequestTimeoutException : CoapClientException
+{
+    /** 
+     * The future we timed out on
+     */
+    private CoapRequestFuture future;
+
+    /**
+     * Timeout time
+     */
+    private Duration timeout;
+
+    /** 
+     * Constructs a new timeout exception for
+     * the given future which timed out
+     *
+     * Params:
+     *   future = the future we timed out on
+     *   timeout = the time duration timed out
+     * on
+     */
+    this(CoapRequestFuture future, Duration timeout)
+    {
+        super("Timed out whilst waiting for "~to!(string)(future)~" after "~to!(string)(timeout));
+        this.future = future;
+        this.timeout = timeout;
+    }
+}

--- a/source/doap/client/exceptions.d
+++ b/source/doap/client/exceptions.d
@@ -41,4 +41,27 @@ public final class RequestTimeoutException : CoapClientException
         this.future = future;
         this.timeout = timeout;
     }
+
+    /** 
+     * Returns the future request which timed
+     * out and cause dthis exception to throw
+     * in the first place
+     *
+     * Returns: the `CoapRequestFuture`
+     */
+    public CoapRequestFuture getFuture()
+    {
+        return this.future;
+    }
+
+    /** 
+     * Returns the timeout period which 
+     * was exceeded
+     *
+     * Returns: the `Duration`
+     */
+    public Duration getTimeout()
+    {
+        return this.timeout;
+    }
 }

--- a/source/doap/client/exceptions.d
+++ b/source/doap/client/exceptions.d
@@ -14,6 +14,10 @@ public class CoapClientException : CoapException
 import doap.client.request : CoapRequestFuture;
 import std.conv : to;
 
+/** 
+ * Thrown when a `CoapRequestFuture` has
+ * a `get(Duration)` call timeout
+ */
 public final class RequestTimeoutException : CoapClientException
 {
     /** 

--- a/source/doap/client/exceptions.d
+++ b/source/doap/client/exceptions.d
@@ -14,7 +14,7 @@ public class CoapClientException : CoapException
 import doap.client.request : CoapRequestFuture;
 import std.conv : to;
 
-package final class RequestTimeoutException : CoapClientException
+public final class RequestTimeoutException : CoapClientException
 {
     /** 
      * The future we timed out on
@@ -35,7 +35,7 @@ package final class RequestTimeoutException : CoapClientException
      *   timeout = the time duration timed out
      * on
      */
-    this(CoapRequestFuture future, Duration timeout)
+    package this(CoapRequestFuture future, Duration timeout)
     {
         super("Timed out whilst waiting for "~to!(string)(future)~" after "~to!(string)(timeout));
         this.future = future;

--- a/source/doap/client/package.d
+++ b/source/doap/client/package.d
@@ -2,3 +2,4 @@ module doap.client;
 
 public import doap.client.client : CoapClient;
 public import doap.client.request : CoapRequestBuilder, CoapRequestFuture, RequestState;
+public import doap.client.exceptions : CoapClientException, RequestTimeoutException;

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -430,8 +430,6 @@ public class CoapRequestFuture
         }
         else
         {
-            // TODO: Make this a specific exception so the user can easily check for it
-            // ... (see feature/cancellable_future for how this would need to be update)
             throw new RequestTimeoutException(this, timeout);
         }
     }

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -340,4 +340,25 @@ public class CoapRequestFuture
         return this.response;
     }
 
+    public CoapPacket get(Duration timeout)
+    {
+        // We can only wait on a condition if we
+        // ... first have a-hold of the lock
+        this.mutex.lock();
+
+        // Await a response
+        if(this.condition.wait(timeout))
+        {
+            // Upon waking up release lock
+            this.mutex.unlock();
+
+            return this.response;
+        }
+        else
+        {
+            // TODO: Make this a specific exception so the user can easily check for it
+            // ... (see feature/cancellable_future for how this would need to be update)
+            throw new CoapException("Timed out whilst waiting");
+        }
+    }
 }

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -280,7 +280,12 @@ public enum RequestState
     /** 
      * The future was cancelled
      */
-    CANCELLED
+    CANCELLED,
+
+    /** 
+     * The future timed out
+     */
+    TIMEDOUT
 }
 
 /** 

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -435,6 +435,7 @@ public class CoapRequestFuture
         }
         else
         {
+            this.state = RequestState.TIMEDOUT;
             throw new RequestTimeoutException(this, timeout);
         }
     }

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -379,7 +379,7 @@ public class CoapRequestFuture
      *
      * Returns: the response as a `CoapPacket`
      * Throws:
-     *     CoapException on cancelled request
+     *     CoapClientException on cancelled request
      */
     public CoapPacket get()
     {
@@ -412,9 +412,9 @@ public class CoapRequestFuture
      *
      * Returns: the response as a `CoapPacket`
      * Throws:
-     *     RequestTimeoutException = on the
+     *     RequestTimeoutException on the
      * future request timing out
-     *     CoapClientException = on cancellation
+     *     CoapClientException on cancellation
      * of the request
      */
     public CoapPacket get(Duration timeout)

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -431,6 +431,7 @@ public class CoapRequestFuture
         // Await a response
         if(this.condition.wait(timeout))
         {
+            this.state = RequestState.COMPLETED;
             return this.response;
         }
         else

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -414,6 +414,8 @@ public class CoapRequestFuture
      * Throws:
      *     RequestTimeoutException = on the
      * future request timing out
+     *     CoapClientException = on cancellation
+     * of the request
      */
     public CoapPacket get(Duration timeout)
     {
@@ -431,8 +433,16 @@ public class CoapRequestFuture
         // Await a response
         if(this.condition.wait(timeout))
         {
-            this.state = RequestState.COMPLETED;
-            return this.response;
+            // If successfully completed
+            if(this.state == RequestState.COMPLETED)
+            {
+                return this.response;
+            }
+            // On error
+            else
+            {
+                throw new CoapClientException("Request future cancelled");
+            }
         }
         else
         {

--- a/source/doap/client/request.d
+++ b/source/doap/client/request.d
@@ -2,7 +2,7 @@ module doap.client.request;
 
 import doap.client.client : CoapClient;
 import doap.protocol;
-import doap.exceptions;
+import doap.client.exceptions;
 import core.time : Duration;
 import std.datetime.stopwatch : StopWatch, AutoStart;
 
@@ -181,12 +181,15 @@ package class CoapRequestBuilder
      * Params:
      *   tkn = the token
      * Returns: this builder
+     * Throws:
+     *      CoapClientException = invalid token
+     * length
      */
     public CoapRequestBuilder token(ubyte[] tkn)
     {
         if(tkn.length > 8)
         {
-            throw new CoapException("The token cannot be more than 8 bytes");
+            throw new CoapClientException("The token cannot be more than 8 bytes");
         }
 
         this.tkn = tkn;
@@ -393,7 +396,7 @@ public class CoapRequestFuture
         // On error
         else
         {
-            throw new CoapException("Request future cancelled");
+            throw new CoapClientException("Request future cancelled");
         }   
     }
 
@@ -415,7 +418,7 @@ public class CoapRequestFuture
         {
             // TODO: Make this a specific exception so the user can easily check for it
             // ... (see feature/cancellable_future for how this would need to be update)
-            throw new CoapException("Timed out whilst waiting");
+            throw new RequestTimeoutException(this, timeout);
         }
     }
     


### PR DESCRIPTION
## Purpose

- Added `get(Duration)` which times out after the provided time has elapsed
 
## Todo :writing_hand: 

- [x] Add unit tests
    - [x] hanging client
        * Was due to the exception throwing and us not getting to the `close()` below
    - [x] Mutex error destroy, some mutex still being held
        * Was because lock was not unlocked in `wait()` timeout case for the condition variable attached to said mutex
    - [x] Add back normal client unit test
- [x] Support for cancelling `get(Duration)`-based waits
- [x] Set state to `TIMEDOUT` on time out
- [x] ~Set state to `COMPLETED` on success~
- [x] Make sure to integrate with new `RequestState` code (as soon as #3 is merged)