### PR TITLE
Remove request when matched by messaging layer

### DIFF
--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -181,7 +181,9 @@ public class CoapClient
 
     /** 
      * Given a token this will try and find an active
-     * request with a matching token and return it
+     * request with a matching token and return it.
+     *
+     * This will also remove it from the requests queue.
      *
      * Params:
      *   token = the token
@@ -200,7 +202,8 @@ public class CoapClient
             {
                 foundRequest = request;
 
-                // FIXME: We should remove it here?
+                outgoingRequests.linearRemoveElement(foundRequest);
+
                 break;
             }
         }

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -201,9 +201,7 @@ public class CoapClient
             if(request.getToken() == token)
             {
                 foundRequest = request;
-
                 outgoingRequests.linearRemoveElement(foundRequest);
-
                 break;
             }
         }

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -199,6 +199,8 @@ public class CoapClient
             if(request.getToken() == token)
             {
                 foundRequest = request;
+
+                // FIXME: We should remove it here?
                 break;
             }
         }


### PR DESCRIPTION
## Purpose

When a messaging layer does `getClient().yankRequest(CoapPacket)` it finds the packet and returns it, but it never removes it. This means it stays in the `outgoingRequest` queue. This has two downsides:

1. It is a memory leak obviously as it is never removed
2. If the retransmission engine sees it then it will cause a retransmission of it, even if it was handled earlier when matched

## Todo :writing_hand: 

- [x] Remove the yanked item
    * Ensure this logic works out for the future retransmission system in #5 . I don't see why it shouldn't because removal only happens when the messaging layer received a reply and wants a match. No need to keep it around in the memory.