### PR TITLE
Implement EXCHANGE_LIFETIME for message ID generation

### DIFF
--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -415,7 +415,7 @@ unittest
                               .post();
 
 
-    client.setExchangeLifetime(dur!("msecs")(180));
+    // client.setExchangeLifetime(dur!("msecs")(180));
 
     writeln("Future start (first)");
     CoapPacket response = future.get();

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -124,8 +124,6 @@ public class CoapClient
      */
     private final ushort newMid2()
     {
-        ushort guessStart = 0;
-
         // Lock rolling counter
         this.rollingLock.lock();
 
@@ -135,6 +133,7 @@ public class CoapClient
             this.rollingLock.unlock();
         }
 
+        // Message IDs which are in use
         ushort[] inUse;
 
         foreach(ushort occupied; this.mids.keys())
@@ -157,9 +156,7 @@ public class CoapClient
         // ... free and use that (also don't forget to register it)
         import doap.utils : findNextFree;
         ushort newMid = findNextFree(inUse);
-
         this.mids[newMid] = StopWatch(AutoStart.yes);
-
 
         return newMid;
     }

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -415,7 +415,8 @@ unittest
                               .post();
 
 
-    // client.setExchangeLifetime(dur!("msecs")(180));
+    // Set it to something high enough (TODO: Change this later)
+    client.setExchangeLifetime(dur!("msecs")(300));
 
     writeln("Future start (first)");
     CoapPacket response = future.get();

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -51,7 +51,7 @@ public class CoapClient
     private ushort rollingMid;
     private Mutex rollingLock;
 
-    import std.datetime.stopwatch : StopWatch;
+    import std.datetime.stopwatch : StopWatch, AutoStart;
     private StopWatch[ushort] mids;
 
     /** 
@@ -145,7 +145,7 @@ public class CoapClient
         import doap.utils : findNextFree;
         ushort newMid = findNextFree(inUse);
 
-        this.mids[newMid] = StopWatch();
+        this.mids[newMid] = StopWatch(AutoStart.yes);
 
 
         return newMid;

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -234,7 +234,7 @@ public class CoapClient
         requestPacket.setCode(requestBuilder.requestCode);
         requestPacket.setPayload(requestBuilder.pyld);
         requestPacket.setToken(requestBuilder.tkn);
-        requestPacket.setMessageId(newMid());
+        requestPacket.setMessageId(newMid2());
 
         // Create the future
         CoapRequestFuture future = new CoapRequestFuture();

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -78,27 +78,6 @@ public class CoapClient
     }
 
     /** 
-     * Generates a new message ID
-     *
-     * Returns: the next message id
-     */
-    private final ushort newMid()
-    {
-        ushort newValue;
-
-        // Lock rolling counter
-        this.rollingLock.lock();
-
-        newValue = this.rollingMid;
-        this.rollingMid++;
-
-        // Unlock rolling counter
-        this.rollingLock.unlock();
-
-        return newValue;
-    }
-
-    /** 
      * Maximum lifetime of a message ID before
      * it is considered for re-use
      */

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -98,8 +98,17 @@ public class CoapClient
         return newValue;
     }
 
+    /** 
+     * Maximum lifetime of a message ID before
+     * it is considered for re-use
+     */
     private Duration EXCHANGE_LIFETIME = dur!("seconds")(500000);
 
+    /** 
+     * Generates a new message ID
+     *
+     * Returns: the next message id
+     */
     private final ushort newMid2()
     {
         ushort guessStart = 0;
@@ -131,8 +140,8 @@ public class CoapClient
             }
         }
 
-        // import doap.
-        return 
+        import doap.utils : findNextFree;
+        return findNextFree(inUse);
     }
 
     /** 

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -105,6 +105,19 @@ public class CoapClient
     private Duration EXCHANGE_LIFETIME = dur!("msecs")(180);
 
     /** 
+     * Sets the exchange lifetime. In other words
+     * the duration of time that must pass before
+     * a message ID is considered free-for-use again
+     *
+     * Params:
+     *   lifetime = the lifetime duration
+     */
+    public void setExchangeLifetime(Duration lifetime)
+    {
+        this.EXCHANGE_LIFETIME = lifetime;
+    }
+
+    /** 
      * Generates a new message ID
      *
      * Returns: the next message id
@@ -381,7 +394,15 @@ version(unittest)
 /**
  * Client testing
  *
- * Tests the rolling of the message id
+ * Tests the rolling of the message id,
+ * here I configure the `EXCHANGE_LIFETIME`
+ * to be a value high enough to not have
+ * them quickly expire.
+ *
+ * NOTE: In the future it may be calculated
+ * in relation to other variables and we may
+ * need a private method accessible here that
+ * can override it
  */
 unittest
 {
@@ -393,6 +414,8 @@ unittest
                               .token([69])
                               .post();
 
+
+    client.setExchangeLifetime(dur!("msecs")(180));
 
     writeln("Future start (first)");
     CoapPacket response = future.get();

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -102,7 +102,7 @@ public class CoapClient
      * Maximum lifetime of a message ID before
      * it is considered for re-use
      */
-    private Duration EXCHANGE_LIFETIME = dur!("seconds")(500000);
+    private Duration EXCHANGE_LIFETIME = dur!("msecs")(10);
 
     /** 
      * Generates a new message ID

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -140,8 +140,15 @@ public class CoapClient
             }
         }
 
+        // If none was available for re-use then find next available
+        // ... free and use that (also don't forget to register it)
         import doap.utils : findNextFree;
-        return findNextFree(inUse);
+        ushort newMid = findNextFree(inUse);
+
+        this.mids[newMid] = StopWatch();
+
+
+        return newMid;
     }
 
     /** 

--- a/source/doap/client/client.d
+++ b/source/doap/client/client.d
@@ -102,7 +102,7 @@ public class CoapClient
      * Maximum lifetime of a message ID before
      * it is considered for re-use
      */
-    private Duration EXCHANGE_LIFETIME = dur!("msecs")(10);
+    private Duration EXCHANGE_LIFETIME = dur!("msecs")(180);
 
     /** 
      * Generates a new message ID

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -142,6 +142,15 @@ unittest
     assert(isPresent(values, 5) == false);
 }
 
+/** 
+ * Given an array of values this tries to find
+ * the next free value of which is NOT present
+ * within the given array
+ *
+ * Params:
+ *   used = the array of values
+ * Returns: the free value
+ */
 public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
 {
     T found;

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -100,6 +100,17 @@ unittest
    
 }
 
+/** 
+ * Checks if the given value is present in
+ * the given array
+ *
+ * Params:
+ *   array = the array to check against
+ *   value = the value to check prescence
+ * for
+ * Returns: `true` if present, `false`
+ * otherwise
+ */
 public bool isPresent(T)(T[] array, T value)
 {
     if(array.length == 0)

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -149,3 +149,10 @@ public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
         return found;
     }
 }
+
+unittest
+{
+    ubyte[] values = [1,2,3];
+    ubyte free = findNextFree(values);
+    assert(isPresent(values, free) == false);
+}

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -83,6 +83,9 @@ version(unittest)
     import std.stdio : writeln;
 }
 
+/**
+ * Tests the `order!(T)(T, Order)`
+ */
 unittest
 {
     version(LittleEndian)

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -30,6 +30,15 @@ public T flip(T)(T bytesIn) if(__traits(isIntegral, T))
     return copy;
 }
 
+/**
+ * Tests the `flip!(T)(T)` function
+ */
+unittest
+{
+    ubyte[] data = [1,2];
+    assert(flip(data) == [2,1]);
+}
+
 /** 
  * Ordering
  */

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -131,6 +131,9 @@ public bool isPresent(T)(T[] array, T value)
     }
 }
 
+/**
+ * Tests the `isPresent!(T)(T[], T)` function
+ */
 unittest
 {
     ubyte[] values = [1,2,3];
@@ -170,6 +173,9 @@ public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
     }
 }
 
+/**
+ * Tests the `findNextFree!(T)(T[])` function
+ */
 unittest
 {
     ubyte[] values = [1,2,3];

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -120,6 +120,17 @@ public bool isPresent(T)(T[] array, T value)
     }
 }
 
+unittest
+{
+    ubyte[] values = [1,2,3];
+    foreach(ubyte value; values)
+    {
+        assert(isPresent(values, value));
+    }
+    assert(isPresent(values, 0) == false);
+    assert(isPresent(values, 5) == false);
+}
+
 public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
 {
     T found;

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -121,23 +121,6 @@ unittest
    
 }
 
-unittest
-{
-    version(LittleEndian)
-    {
-        ushort i = 1;
-        writeln("Pre-order: ", i);
-        ushort ordered = order(i, Order.BE);
-        writeln("Post-order: ", ordered);
-        assert(ordered == 256);
-    }
-    else version(BigEndian)
-    {
-        // TODO: Add this AND CI tests for it
-    }
-   
-}
-
 /** 
  * Checks if the given value is present in
  * the given array

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -3,6 +3,11 @@
  */
 module doap.utils;
 
+version(unittest)
+{
+    import std.stdio : writeln;
+}
+
 /** 
  * Flips the given integral value
  *
@@ -75,12 +80,6 @@ public T order(T)(T bytesIn, Order order) if(__traits(isIntegral, T))
             return flip(bytesIn);
         }
     }
-}
-
-
-version(unittest)
-{
-    import std.stdio : writeln;
 }
 
 /**

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -35,8 +35,18 @@ public T flip(T)(T bytesIn) if(__traits(isIntegral, T))
  */
 unittest
 {
-    ubyte[] data = [1,2];
-    assert(flip(data) == [2,1]);
+    version(BigEndian)
+    {
+        ushort i = 1;
+        ushort flipped = flip(i);
+        assert(flipped == 256);
+    }
+    else version(LittleEndian)
+    {
+        ushort i = 1;
+        ushort flipped = flip(i);
+        assert(flipped == 256);
+    }
 }
 
 /** 

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -161,7 +161,7 @@ public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
     else
     {
         found = 0;
-        while(isPresent(used, found))
+        while(isPresent(used, found)) // FIXME: Constant loop if none available
         {
             found++;
         }

--- a/source/doap/utils.d
+++ b/source/doap/utils.d
@@ -99,3 +99,42 @@ unittest
     }
    
 }
+
+public bool isPresent(T)(T[] array, T value)
+{
+    if(array.length == 0)
+    {
+        return false;
+    }
+    else
+    {
+        foreach(T cur; array)
+        {
+            if(cur == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+public T findNextFree(T)(T[] used) if(__traits(isIntegral, T))
+{
+    T found;
+    if(used.length == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        found = 0;
+        while(isPresent(used, found))
+        {
+            found++;
+        }
+
+        return found;
+    }
+}


### PR DESCRIPTION
## Purpose

This is to implement the `EXCHANGE_LIFETIME` mechanism which posits an upper bound on the lifetime of validity for a message ID, in which a message ID is still considered "in use" but over which it is available for re-usage. If it is "in use" then we must generate the next available free one.

## Todo :writing_hand: 

- [x] Lifetime mechanism and message ID generation
- [x] Switch to `newMid2()`
    - [ ] In future, `onNoNewMessages()` can perform a clean up as we might have a leaky memory moment if we just constantly reuse first entry and never clean out the others - we can make this configurable so as to also not always reallocate new `Stopwatch` instances
- [x] Deprecate `newMid()`
    - [x] I want to test out expiration